### PR TITLE
Fix a bug.

### DIFF
--- a/plugins/contribute.py
+++ b/plugins/contribute.py
@@ -47,9 +47,9 @@ class ContributeHandler:
                   "%s \n" \
                   "Tags %s   \n" \
                   "From [%s](%s)" % (
-                      escape_markdown(artwork_info.title),
+                      escape_markdown(artwork_info.title, version=2),
                       artwork_info.GetStringStat(),
-                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                       artwork_info.site_name,
                       artwork_info.origin_url
                   )

--- a/plugins/examine.py
+++ b/plugins/examine.py
@@ -156,9 +156,9 @@ class ExamineHandler:
                           "%s \n" \
                           "Tags %s   \n" \
                           "From [%s](%s)" % (
-                              escape_markdown(artwork_info.title),
+                              escape_markdown(artwork_info.title, version=2),
                               artwork_info.GetStringStat(),
-                              escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                              escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                               artwork_info.site_name,
                               artwork_info.origin_url
                           )

--- a/plugins/photo.py
+++ b/plugins/photo.py
@@ -89,9 +89,9 @@ class PhotoHandler:
                   "%s   \n" \
                   "Tags %s   \n" \
                   "From [%s](%s)" % (
-                      escape_markdown(artwork_info.title),
+                      escape_markdown(artwork_info.title, version=2),
                       artwork_info.GetStringStat(),
-                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                       artwork_info.site_name,
                       artwork_info.origin_url
                   )

--- a/plugins/push.py
+++ b/plugins/push.py
@@ -99,8 +99,8 @@ class PushHandler:
                 caption = "Title %s   \n" \
                           "Tags %s   \n" \
                           "From [%s](%s)" % (
-                              escape_markdown(artwork_info.title),
-                              escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                              escape_markdown(artwork_info.title, version=2),
+                              escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                               artwork_info.site_name,
                               artwork_info.origin_url
                           )

--- a/plugins/send.py
+++ b/plugins/send.py
@@ -82,9 +82,9 @@ class SendHandler:
                   "%s   \n" \
                   "Tags %s   \n" \
                   "From [%s](%s)" % (
-                      escape_markdown(artwork_info.title),
+                      escape_markdown(artwork_info.title, version=2),
                       artwork_info.GetStringStat(),
-                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                       artwork_info.site_name,
                       artwork_info.origin_url
                   )
@@ -156,8 +156,8 @@ class SendHandler:
         caption = "Title %s   \n" \
                   "Tags %s   \n" \
                   "From [%s](%s)" % (
-                      escape_markdown(artwork_info.title),
-                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                      escape_markdown(artwork_info.title, version=2),
+                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                       artwork_info.site_name,
                       artwork_info.origin_url
                   )

--- a/plugins/set_audit.py
+++ b/plugins/set_audit.py
@@ -101,9 +101,9 @@ class SetAuditHandler:
                       audit_info.type.name,
                       audit_info.status.name,
                       audit_info.site,
-                      escape_markdown(artwork_info.title),
+                      escape_markdown(artwork_info.title, version=2),
                       artwork_info.GetStringStat(),
-                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True)),
+                      escape_markdown(artwork_info.GetStringTags(filter_character_tags=True), version=2),
                       artwork_info.site_name,
                       artwork_info.origin_url
                   )


### PR DESCRIPTION
```
Traceback
Can't parse entities: character '#' is reserved and must be escaped with the preceding '\'
```

The `escape_markdown` default `version` value is 1.

But `parse_mode` is `MARKDOWN_V2`.

Use the `escape_markdown` to set `version` value to `2`.