### PR TITLE
Fix redis to handle empty cache in `push` queue

### DIFF
--- a/service/cache.py
+++ b/service/cache.py
@@ -171,9 +171,9 @@ class ServiceCache:
             art_key = pipe.srandmember(qname.push)
             count = pipe.scard(qname.push)
             pipe.multi()
-            pipe.srem(qname.push, art_key)
             if art_key is None:
                 return None, count
+            pipe.srem(qname.push, art_key)
             return art_key, count - 1
 
         return self.rdb.transaction(update_queue, qname.push, value_from_callable=True)

--- a/tests/integration/test_redis_cache.py
+++ b/tests/integration/test_redis_cache.py
@@ -1,0 +1,26 @@
+import os
+import unittest
+
+from service.cache import ServiceCache
+from model.artwork import AuditType
+
+
+class TestPixivService(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        redis_config = {
+            'host': os.environ.get('REDIS_HOST', default='127.0.0.1'),
+            'port': int(os.environ.get('REDIS_PORT', default='6379')),
+            'db': int(os.environ.get('REDIS_DATABASE', default='4')),
+        }
+        sc = ServiceCache(**redis_config)
+        cls.sc = sc
+
+    def test_no_op(self):
+        pass
+    
+    def test_get_push_one_should_not_fail_when_empty(self):
+        artwork_info, count = self.sc.get_push_one(AuditType.SFW)
+        self.assertEqual(artwork_info, None)
+        self.assertEqual(count, 0)


### PR DESCRIPTION
Redis throws an exception on `.srem` if cache is empty

## Before

![image](https://user-images.githubusercontent.com/17893236/156917735-5e0672fa-2350-47b3-8f74-cb4c51c4e9d1.png)

```
E.
======================================================================
ERROR: test_get_push_one_should_not_fail_when_empty (tests.integration.test_redis_cache.TestPixivService)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kotori/TGGenshinPicBed_Bot/tests/integration/test_redis_cache.py", line 24, in test_get_push_one_should_not_fail_when_empty
    self.sc.get_push_one(AuditType.SFW)
  File "/home/kotori/TGGenshinPicBed_Bot/service/cache.py", line 179, in get_push_one
    return self.rdb.transaction(update_queue, qname.push, value_from_callable=True)
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/client.py", line 805, in transaction
    exec_value = pipe.execute()
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/client.py", line 4019, in execute
    return execute(conn, stack, raise_on_error)
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/client.py", line 3884, in _execute_transaction
    all_cmds = connection.pack_commands([args for args, options in cmds
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/connection.py", line 801, in pack_commands
    for chunk in self.pack_command(*cmd):
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/connection.py", line 775, in pack_command
    for arg in imap(self.encoder.encode, args):
  File "/home/kotori/TGGenshinPicBed_Bot/venv/lib/python3.8/site-packages/redis/connection.py", line 119, in encode
    raise DataError("Invalid input of type: '%s'. Convert to a "
redis.exceptions.DataError: Invalid input of type: 'NoneType'. Convert to a bytes, string, int or float first.
```

## After

![image](https://user-images.githubusercontent.com/17893236/156917748-3434329d-0451-4d0a-9a02-8a807c70ee12.png)

```
----------------------------------------------------------------------
Ran 2 tests in 0.002s
```